### PR TITLE
User can now change their file input type

### DIFF
--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -13,7 +13,9 @@ export default function SettingsModal({ isOpen, setIsOpen }) {
 	const [isReady, setIsReady] = useState(false);
 	const [selectedInputType, setSelectedInputType] = useState<Input>(null);
 	const [selectedOutputType, setSelectedOutputType] = useState<Input>(null);
-	const [selectedImageQuality, setSelectedImageQuality] = useState<number>(90);
+	const [selectedImageQuality, setSelectedImageQuality] = useState<number>(85);
+	const [filteredInputTypes, setFilteredInputTypes] = useState<Input[]>([]);
+	const [filteredOutputTypes, setFilteredOutputTypes] = useState<Input[]>([]);
 
 	const cancelButtonRef = useRef(null);
 
@@ -43,6 +45,22 @@ export default function SettingsModal({ isOpen, setIsOpen }) {
 			setIsReady(true);
 		}
 	}, [settings]);
+
+	useEffect(() => {
+		if (selectedOutputType) {
+			setFilteredInputTypes(
+				settingsInputTypes.filter((input) => input.id !== selectedOutputType.id)
+			);
+		}
+	}, [selectedOutputType]);
+
+	useEffect(() => {
+		if (selectedInputType) {
+			setFilteredOutputTypes(
+				fileTypes.filter((fileType) => fileType.id !== selectedInputType.id)
+			);
+		}
+	}, [selectedInputType]);
 
 	return (
 		<Transition.Root show={isOpen} as={Fragment}>
@@ -99,16 +117,15 @@ export default function SettingsModal({ isOpen, setIsOpen }) {
 													<div className="flex-auto w-50 mr-1">
 														<SelectInput
 															inputLabel="Input"
-															inputList={settingsInputTypes}
+															inputList={filteredInputTypes}
 															selectedInput={selectedInputType}
-															isDisabled
 															handleSelectedInput={setSelectedInputType}
 														/>
 													</div>
 													<div className="flex-auto w-50 ml-1">
 														<SelectInput
 															inputLabel="Output"
-															inputList={fileTypes}
+															inputList={filteredOutputTypes}
 															selectedInput={selectedOutputType}
 															handleSelectedInput={setSelectedOutputType}
 														/>

--- a/context/SettingsProvider.tsx
+++ b/context/SettingsProvider.tsx
@@ -22,9 +22,9 @@ type SettingsContextProperties = {
 };
 
 const defaultSettings: Settings = {
-	fileInputId: FileType.png,
+	fileInputId: FileType.heic,
 	fileOutputId: FileType.jpeg,
-	imageQuality: 100,
+	imageQuality: 85,
 };
 
 const SettingsContext = createContext<SettingsContextProperties>({
@@ -90,7 +90,7 @@ const SettingsProvider = ({ ...properties }: Properties) => {
 			updateSettings({
 				fileInputId: input === null ? defaultSettings.fileInputId : input,
 				fileOutputId: output === null ? defaultSettings.fileOutputId : output,
-				imageQuality: imageQuality === 0 ? 100 : imageQuality,
+				imageQuality: imageQuality === 0 ? 85 : imageQuality,
 			});
 		}
 	}, [settings]);

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,8 +23,8 @@ export const fileTypes: Input[] = [
 
 export const settingsInputTypes: Input[] = [
 	{ id: "heic", name: ".HEIC", unavailable: false },
-	{ id: "jpeg", name: ".JPEG", unavailable: true },
-	{ id: "png", name: ".PNG", unavailable: true },
+	{ id: "jpeg", name: ".JPEG", unavailable: false },
+	{ id: "png", name: ".PNG", unavailable: false },
 ];
 
 export interface UploadOption {


### PR DESCRIPTION
## In this PR:
- User can now select input file types.
- We now filter the input type options based on the selected output type. This means a user can't set a given file type as input and output.
- For now users can only set heic images as an input and not output type.